### PR TITLE
Fixed connected method.

### DIFF
--- a/background.js
+++ b/background.js
@@ -79,7 +79,7 @@ var autoUpdateBadge = function() {
  * @return boolean
  */
 var connected = function() {
-	return (localStorage.token != "");
+    return (localStorage.token !== undefined && localStorage.token !== '');
 };
 
 /**


### PR DESCRIPTION
localStorage.token returns undefined when localStorage has been cleared.
Changed the connected method to check for undefined too.
